### PR TITLE
handle withkeys values being escaped

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=2.6
+version=2.6.1
 
 ossrhUsername=me
 ossrhPassword=you

--- a/src/main/java/com/datamountaineer/kcql/Kcql.java
+++ b/src/main/java/com/datamountaineer/kcql/Kcql.java
@@ -724,7 +724,7 @@ public class Kcql {
         if (kcql.withKeys == null) {
           kcql.withKeys = new ArrayList<>();
         }
-        kcql.withKeys.add(key);
+        kcql.withKeys.add(unescape(key));
       }
 
       @Override
@@ -791,7 +791,7 @@ public class Kcql {
   }
 
   private static String unescape(String value) {
-    if (value.startsWith("`")) {
+    if (value.startsWith("`") && value.endsWith("`")) {
       return value.substring(1, value.length() - 1);
     }
     return value;

--- a/src/test/java/com/datamountaineer/kcql/KcqlTest.java
+++ b/src/test/java/com/datamountaineer/kcql/KcqlTest.java
@@ -747,6 +747,18 @@ public class KcqlTest {
   }
 
   @Test
+  public void handleWithKeyEscaped() {
+    String topic = "TOPIC_A";
+    String table = "TABLE_A";
+    String syntax = "INSERT INTO %s SELECT @col1, col2,col3 FROM %s WITHKEY(`col1`, `col2`)";
+    Kcql kcql = Kcql.parse(syntax);
+    List<String> withKeys = kcql.getWithKeys();
+    assertEquals("col1", withKeys.get(0));
+    assertEquals("col2", withKeys.get(1));
+    assertEquals(2, withKeys.size());
+  }
+
+  @Test
   public void handleStoredAs() {
     String topic = "TOPIC_A";
     String table = "TABLE_A";


### PR DESCRIPTION
bumping the version to 2.6.1

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/landoop/kafka-connect-query-language/27)
<!-- Reviewable:end -->
