### PR TITLE
fix(grammar): allow topics starting with dollar

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=2.8.3
+version=2.8.4
 
 ossrhUsername=me
 ossrhPassword=you

--- a/src/main/antlr/ConnectorLexer.g4
+++ b/src/main/antlr/ConnectorLexer.g4
@@ -260,7 +260,7 @@ FIELD
 
 
 TOPICNAME
-   : ( 'a' .. 'z' | 'A' .. 'Z' | '_' | '0' .. '9' | '-' | '+' | '/' |'{'|'}'|':' )+ | ESCAPED_TOPIC
+   : ( 'a' .. 'z' | 'A' .. 'Z' | '_' | '0' .. '9' | '-' | '+' | '/' |'{'|'}'|':'|'$' )+ | ESCAPED_TOPIC
    ;
 
 KEYDELIMVALUE

--- a/src/test/java/com/datamountaineer/kcql/KcqlTest.java
+++ b/src/test/java/com/datamountaineer/kcql/KcqlTest.java
@@ -78,6 +78,19 @@ public class KcqlTest {
   }
 
   @Test
+  public void parseAnInsertWithSelectAllFieldsAndTopicStartsWithDollar() {
+    String topic = "$TOPIC_A";
+    String table = "$TABLE_A";
+    String syntax = String.format("INSERT INTO %s SELECT * FROM %s", table, topic);
+    Kcql kcql = Kcql.parse(syntax);
+    assertEquals(topic, kcql.getSource());
+    assertEquals(table, kcql.getTarget());
+    assertFalse(kcql.getFields().isEmpty());
+    assertTrue(kcql.getFields().get(0).getName().equals("*"));
+    assertEquals(WriteModeEnum.INSERT, kcql.getWriteMode());
+  }
+
+  @Test
   public void handleTargetAndSourceContainingDot() {
     String topic = "TOPIC.A";
     String table = "TABLE.A";


### PR DESCRIPTION
Added dollar character to TOPICNAME in ConnectorLexer.g4
Added one test
Changed version to 2.8.4

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/landoop/kafka-connect-query-language/35)
<!-- Reviewable:end -->
